### PR TITLE
Fix for ck.Type.HTTP.IPv6 undefined (type *pingdom.CheckResponseHTTPD…

### DIFF
--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -204,6 +204,7 @@ type CheckResponseHTTPDetails struct {
 	RequestHeaders    map[string]string `json:"requestheaders,omitempty"`
 	VerifyCertificate bool              `json:"verify_certificate,omitempty"`
 	SSLDownDaysBefore int               `json:"ssl_down_days_before,omitempty"`
+	IPv6              bool              `json:"ipv6,omitempty"`
 }
 
 // CheckResponseTCPDetails represents the details specific to TCP checks.

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -56,6 +56,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 				"responsetime_threshold": "2300",
 				"verify_certificate":     "true",
 				"ssl_down_days_before":   "10",
+				"ipv6":                   "false",
 			},
 		},
 		{
@@ -95,6 +96,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 				"userids":                "123,456",
 				"teamids":                "789",
 				"responsetime_threshold": "2300",
+				"ipv6":                   "false",
 			},
 		},
 	}
@@ -147,6 +149,7 @@ func TestHttpCheckPostParams(t *testing.T) {
 		"responsetime_threshold": "2300",
 		"verify_certificate":     "true",
 		"ssl_down_days_before":   "10",
+		"ipv6":                   "false",
 	}
 
 	params := check.PostParams()


### PR DESCRIPTION
…etails has no field or method IPv6)